### PR TITLE
Fixed Wrapper Order, Added Ground Truch Changes to Info Dict

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,5 +195,10 @@ pytest tests/
 After forking the repo make a new branch for your feature or bugfix (e.g, `git checkout -b feature/new-non-stationary-env`), commit your changes, and push the branch to your fork. Then, open a pull request against the main repository's `main` branch.
 
 
+To run tox tests to test against multiple Python versions, navigate to the root directory of the project and run:
 
+```bash
+tox 
+```
 
+To versioning is handled via `setuptools_scm`. When we tag a new release, the version number will be automatically updated based on the latest tag. 

--- a/ns_gym/__init__.py
+++ b/ns_gym/__init__.py
@@ -9,6 +9,14 @@ from . import context_switching
 from . import utils
 from . import envs
 
+from importlib.metadata import version, PackageNotFoundError
+
+try:
+    __version__ = version("ns_gym")
+except PackageNotFoundError:
+    # package is not installed
+    __version__ = "0.0.0-unknown"
+
 register(
     id='ns_gym/Bridge-v0',
     entry_point='ns_gym.envs:Bridge',

--- a/ns_gym/wrappers/toy_text.py
+++ b/ns_gym/wrappers/toy_text.py
@@ -167,8 +167,11 @@ class NSCliffWalkingWrapper(base.NSWrapper):
             tuple[dict, base.Reward, bool, bool, dict[str, Any]]: The observation, reward, termination signal, truncation signal, and additional information.       
         """
         if self.is_sim_env and not self.in_sim_change:
+            env_change = {"P": 0}
+            delta_change = {"P": 0.0}
+
             obs, reward, terminated, truncated, info = super().step(
-                action, env_change=None, delta_change=None
+                action, env_change=env_change, delta_change=delta_change
             )
         else:
             self.transition_prob, env_change_flag, delta_change = self.update_fn(
@@ -217,7 +220,9 @@ class NSCliffWalkingWrapper(base.NSWrapper):
         return planning_env
 
     def __deepcopy__(self, memo):
-        env_id = self.unwrapped.spec.id
+        # env_id = self.unwrapped.spec.id
+
+        env_id = "CliffWalking-v1"
         sim_env = NSCliffWalkingWrapper(
             gym.make(env_id, max_episode_steps=1000),
             tunable_params=deepcopy(self.tunable_params, memo),
@@ -343,8 +348,10 @@ class NSFrozenLakeWrapper(base.NSWrapper):
 
         if self.is_sim_env and not self.in_sim_change:
             # action = self._get_action(action)
+            env_change = {"P": 0}
+            delta_change = {"P": 0.0}
             obs, reward, terminated, truncated, info = super().step(
-                action, env_change=None, delta_change=None
+                action, env_change=env_change, delta_change=delta_change
             )
         else:
             self.transition_prob, env_change_flag, delta_change = self.update_fn(
@@ -468,9 +475,11 @@ class NSFrozenLakeWrapper(base.NSWrapper):
         return planning_env
 
     def __deepcopy__(self, memo):
-        env_id = self.unwrapped.spec.id
+        # env_id = self.unwrapped.spec.id
+        env_id = "FrozenLake-v1"
+
         sim_env = gym.make(
-            env_id, is_slippery=False, max_episode_steps=1000, render_mode="ansi"
+            env_id, is_slippery=False, render_mode="ansi", 
         )
         sim_env = NSFrozenLakeWrapper(
             sim_env,


### PR DESCRIPTION
# Changes

- Fixed wrapper order when getting planning env and using `gym.make("env-id")`  registration API.
- Added ground truth environment change dictionary to `info` object 