### PR TITLE
default to scalar reward

### DIFF
--- a/ns_gym/base.py
+++ b/ns_gym/base.py
@@ -197,6 +197,7 @@ class NSWrapper(Wrapper):
         change_notification: bool = False,
         delta_change_notification: bool = False,
         in_sim_change: bool = False,
+        scalar_reward: bool = True,
         **kwargs: Any,
     ):
         """
@@ -206,6 +207,7 @@ class NSWrapper(Wrapper):
             change_notification (bool): Sets a basic notification level. Returns a boolean flag to indicate whether to notify the agent of changes in the environment. Defaults to False.
             delta_change_notification (bool): Sets detailed notification levle. Returns Flag to indicate whether to notify the agent of changes in the transition function. Defaults to False.
             in_sim_change (bool): Flag to indicate whether to allow changes in the environment during simulation (e.g MCTS rollouts). Defaults to False.
+            scalar_reward (bool): If True, step() returns a scalar reward. If False, step() returns a Reward dataclass containing the reward, env_change, delta_change, and relative_time. Defaults to True.
 
         Attributes:
             frozen (bool): Flag to indicate whether the environment is frozen or not.
@@ -213,6 +215,8 @@ class NSWrapper(Wrapper):
 
         """
         Wrapper.__init__(self, env)
+
+        self.scalar_reward = scalar_reward
 
         if delta_change_notification:
             assert change_notification, (
@@ -311,13 +315,15 @@ class NSWrapper(Wrapper):
             "relative_time": self.t,
         }
 
-        rew = Reward(
-            reward=reward,
-            env_change=final_env_change,
-            delta_change=final_delta_change,
-            relative_time=self.t,
-        )
-
+        if self.scalar_reward:
+            rew = reward
+        else:
+            rew = Reward(
+                reward=reward,
+                env_change=final_env_change,
+                delta_change=final_delta_change,
+                relative_time=self.t,
+            )
 
         info["Ground Truth Env Change"] = calculated_env_change
         info["Ground Truth Delta Change"] = calculated_delta_change

--- a/ns_gym/wrappers/classic_control.py
+++ b/ns_gym/wrappers/classic_control.py
@@ -167,6 +167,7 @@ class NSClassicControlWrapper(base.NSWrapper):
             self.change_notification,
             self.delta_change_notification,
             self.in_sim_change,
+            scalar_reward=self.scalar_reward,
         )
         sim_env.reset()
         sim_env.unwrapped.state = deepcopy(self.unwrapped.state)

--- a/ns_gym/wrappers/toy_text.py
+++ b/ns_gym/wrappers/toy_text.py
@@ -45,6 +45,7 @@ class NSCliffWalkingWrapper(base.NSWrapper):
             change_notification=change_notification,
             delta_change_notification=delta_change_notification,
             in_sim_change=in_sim_change,
+            **kwargs,
         )
 
         self.shape = self.unwrapped.shape
@@ -230,6 +231,7 @@ class NSCliffWalkingWrapper(base.NSWrapper):
             delta_change_notification=self.delta_change_notification,
             in_sim_change=self.in_sim_change,
             initial_prob_dist=self.initial_prob_dist,
+            scalar_reward=self.scalar_reward,
         )
         memo[id(self)] = sim_env
 
@@ -489,6 +491,7 @@ class NSFrozenLakeWrapper(base.NSWrapper):
             in_sim_change=self.in_sim_change,
             initial_prob_dist=self.initial_prob_dist,
             modified_rewards=self.modified_rewards,
+            scalar_reward=self.scalar_reward,
         )
         sim_env.reset()
         sim_env.unwrapped.s = deepcopy(self.unwrapped.s)
@@ -516,6 +519,7 @@ class NSBridgeWrapper(base.NSWrapper):
         in_sim_change: bool = False,
         initial_prob_dist=[1, 0, 0],
         modified_rewards: Union[dict[str, int], None] = None,
+        **kwargs: Any,
     ):
         super().__init__(
             env=env,
@@ -523,6 +527,7 @@ class NSBridgeWrapper(base.NSWrapper):
             change_notification=change_notification,
             delta_change_notification=delta_change_notification,
             in_sim_change=in_sim_change,
+            **kwargs,
         )
 
         self.initial_prob_dist = initial_prob_dist
@@ -584,6 +589,7 @@ class NSBridgeWrapper(base.NSWrapper):
             delta_change_notification=self.delta_change_notification,
             in_sim_change=self.in_sim_change,
             initial_prob_dist=self.initial_prob_dist,
+            scalar_reward=self.scalar_reward,
         )
         sim_env.reset()
         sim_env.unwrapped.s = deepcopy(self.unwrapped.s)


### PR DESCRIPTION
# Defaulting to scalar rewards. 

Originally, we wanted to use a custom reward structure to handle notification information for potentially non-stationary reward functions. However, that is confusing and a pain to do type checking whenever interfacing with decision-making algorithms, i.e., StableBaselines-3 API or existing MCTS implementations. 

So now all envs return as expected a simple reward scalar. Setting the optional keyword argument `scalar_reward=False` will return the old Reward struct. 